### PR TITLE
Update cache directory default for 2.x

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -81,10 +81,10 @@ src_img_root = '/usr/local/share/images' # r--
 # head_resolvable = False
 
 [img.ImageCache]
-cache_dp = '/var/cache/loris' # rwx
+cache_dp = '/var/cache/loris2' # rwx
 
 [img_info.InfoCache]
-cache_dp = '/var/cache/loris' # rwx
+cache_dp = '/var/cache/loris2' # rwx
 
 [transforms]
 dither_bitonal_images = False


### PR DESCRIPTION
When I installed Loris for IIIF 2.0, it didn't run out of the box because the default `loris2.conf` referenced `/var/cache/loris`, which doesn't exist. Changing it to `/var/cache/loris2` should make it easier to get started.
